### PR TITLE
Fix realpath error on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 on: [push, pull_request]
 jobs:
   shellspec:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       packages: read
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+* Improvements
+    * Command `grealpath` will be used instead of `realpath`, if
+      installed. On macOS, this is helpful because many users have a
+      broken `realpath` command and install a working version of the
+      command under `grealpath` instead (via Homebrew).
+
 ## 2.1.0 (2022-05-10)
 
 * Features

--- a/pass-ln.bash
+++ b/pass-ln.bash
@@ -56,8 +56,9 @@ cmd_ln() {
     link_dir="$(dirname -- "${link_filename}")" || exit
     realpath_cmd="realpath"
     if [[ "$(uname)" == "Darwin" ]]; then
-        if [[ -n "$(command -v grealpath 2>/dev/null)" ]]; then
-            # On macOS, use GNU realpath as provided via `coreutils` Homebrew formula if available
+        if command -v grealpath &>/dev/null; then
+            # On macOS, use GNU realpath as provided via `coreutils`
+            # Homebrew formula if available
             realpath_cmd="grealpath"
         fi
     fi

--- a/pass-ln.bash
+++ b/pass-ln.bash
@@ -54,7 +54,11 @@ cmd_ln() {
         die "Error: refusing to overwrite ${link_name}."
     fi
     link_dir="$(dirname -- "${link_filename}")" || exit
-    target_relative_path="$(realpath -m --relative-to="${link_dir}" -- "${target_filename}")" || exit
+    realpath_cmd="realpath"
+    if [[ "$(uname)" == "Darwin" ]]; then
+        realpath_cmd="grealpath" # GNU coreutils realpath when installed via Homebrew
+    fi
+    target_relative_path="$("$realpath_cmd" -m --relative-to="${link_dir}" -- "${target_filename}")" || exit
     set_git "${PREFIX}/${link_filename}"
     mkdir -p "${PREFIX}/${link_dir}" || exit
     ln -s "${target_relative_path}" "${PREFIX}/${link_filename}" || exit

--- a/pass-ln.bash
+++ b/pass-ln.bash
@@ -56,7 +56,10 @@ cmd_ln() {
     link_dir="$(dirname -- "${link_filename}")" || exit
     realpath_cmd="realpath"
     if [[ "$(uname)" == "Darwin" ]]; then
-        realpath_cmd="grealpath" # GNU coreutils realpath when installed via Homebrew
+        if [[ -n "$(command -v grealpath 2>/dev/null)" ]]; then
+            # On macOS, use GNU realpath as provided via `coreutils` Homebrew formula if available
+            realpath_cmd="grealpath"
+        fi
     fi
     target_relative_path="$("$realpath_cmd" -m --relative-to="${link_dir}" -- "${target_filename}")" || exit
     set_git "${PREFIX}/${link_filename}"


### PR DESCRIPTION
This makes it so that `grealpath` is run instead of `realpath` on macOS to explicitly use the GNU version provided by the `coreutils` formula. This is needed because the built-in macOS version of realpath does not support the required flags.

Closes #6 